### PR TITLE
Use & operator instead of extends keyword

### DIFF
--- a/lib/giscus.ts
+++ b/lib/giscus.ts
@@ -8,7 +8,7 @@ type vitepressAPI = {
     route: Route
 }
 
-interface GiscusPropsType extends GiscusProps {
+type GiscusPropsType = GiscusProps & {
     lightTheme?: string,
     darkTheme?: string
 }


### PR DESCRIPTION
`&` 用于扩展属性，`extends`用于扩展方法，所以使用`extends`会导致使用该方法时tsc报错